### PR TITLE
@ #10 | should use standard /mnt/data instead of /data for aws-cli volume

### DIFF
--- a/aws-cli/README.md
+++ b/aws-cli/README.md
@@ -1,3 +1,51 @@
-teracy/aws-cli Docker image
-===========================
+# teracy/aws-cli Docker image
 
+Docker image to work with Amazon AWS via aws-cli and aws-shell.
+
+
+# How to use
+
+- Start a container and get a shell with environment variables:
+
+```
+$ docker run --rm -it \
+  -e AWS_ACCESS_KEY_ID=<YOUR AWS ACCESS KEY ID> \
+  -e AWS_SECRET_ACCESS_KEY=<YOUR AWS SCRET ACCESS KEY> \
+  -e AWS_DEFAULT_REGION=<YOUR AWS DEFAULT REGION> \
+  -v $(pwd):/mnt/data \
+  teracy/aws-cli /bin/bash
+```
+
+
+- Start a container and get a shell by configuring and reuse the config:
+
+```
+$ docker run --rm -it \
+  -v $(pwd)/.aws:/root/.aws \
+  -v $(pwd):/mnt/data \
+  teracy/aws-cli /bin/bash
+```
+
+After that, you can configure:
+
+```
+root@0d27cd621361:/mnt/data# aws configure
+```
+
+
+- To enable auto complete feature for aws-cli after getting the shell:
+
+```
+root@0d27cd621361:/mnt/data# complete -C /usr/local/bin/aws_completer aws
+```
+
+- Start a container and use aws-shell:
+
+```
+$ docker run --rm -it \
+  -v $(pwd)/.aws:/root/.aws \
+  -v $(pwd):/mnt/data \
+  teracy/aws-cli aws-shell
+```
+
+And you can use all the supported `aws-cli` or `aws-shell` commands.

--- a/aws-cli/latest/Dockerfile
+++ b/aws-cli/latest/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:2.7-alpine
+FROM python:2.7
+
 
 LABEL authors="hoatle <hoatle@teracy.com>"
 
@@ -13,6 +14,20 @@ ARG CI_BUILD_TIME
 ENV CI_BUILD_ID=$CI_BUILD_ID CI_BUILD_REF=$CI_BUILD_REF CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE \
     CI_PROJECT_NAME=$CI_PROJECT_NAME CI_BUILD_REF_NAME=$CI_BUILD_REF_NAME CI_BUILD_TIME=$CI_BUILD_TIME
 
-RUN pip --no-cache-dir install awscli
+# for aws help: https://github.com/aws/aws-cli/issues/1957
+RUN apt-get update \
+  && apt-get install -y -qq groff less
 
-WORKDIR /data
+RUN pip --no-cache-dir install awscli \
+  && mkdir ~/.aws \
+  && mkdir -p /mnt/data \
+  && pip --no-cache-dir install aws-shell
+
+# TODO(hoatle): add completion support
+# $ complete -C '/usr/local/bin/aws_completer' aws
+# http://docs.aws.amazon.com/cli/latest/userguide/cli-command-completion.html
+
+WORKDIR /mnt/data
+
+# Expose volume for adding credentials
+VOLUME ["~/.aws", "/mnt/data"]


### PR DESCRIPTION
fixes #10 